### PR TITLE
Bug fixes on preprocessing and knnsearch

### DIFF
--- a/src/knn_search.rs
+++ b/src/knn_search.rs
@@ -6,7 +6,7 @@ pub fn knn_search<'a>(
     xb: &'a DMatrix<f64>,
     search_size: usize,
 ) -> DMatrix<usize> {
-    let mut kdtree: KdTree<f64, usize, 3, 1024, u32> = KdTree::with_capacity(xa.nrows());
+    let mut kdtree: KdTree<f64, usize, 3, 8192, u32> = KdTree::with_capacity(xa.nrows());
     let mut knn_indices = DMatrix::zeros(xb.nrows(), search_size);
     xa.row_iter().enumerate().for_each(|(idx, point)| {
         kdtree.add(&[point[0], point[1], point[2]], idx);

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -1,7 +1,7 @@
 use crate::utils;
 use na::DMatrix;
 use ordered_float::OrderedFloat;
-use std::{collections::HashMap, vec};
+use std::{collections::BTreeMap, vec};
 
 fn vec_mean(
     vector: Vec<(OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>)>,
@@ -25,10 +25,10 @@ pub fn duplicate_merging<'a>(
     points: &'a na::DMatrix<f64>,
     colors: &'a na::DMatrix<u8>,
 ) -> (na::DMatrix<f64>, na::DMatrix<u8>) {
-    let mut points_map: HashMap<
+    let mut points_map: BTreeMap<
         (OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>),
         Vec<(OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>)>,
-    > = HashMap::new();
+    > = BTreeMap::new();
     for i in 0..points.nrows() {
         let point = points.row(i);
         let point = (


### PR DESCRIPTION
- Replace the HashMap on the duplicate merging function to a BTreeMap t…o fix a bug where similar points would be considered equal

- Also increase bucket size on knnsearch to prevent a crash related to too many points on the same node