### PR TITLE
Replace kiddo with kdtree in order to fix the bucket_size limitation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 nalgebra = "0.32.5"
 ordered-float = "4.0"
 num-traits = "0.2.19"
-kiddo = "4.2.0"
 libm = "0.2.8"
 ply-rs = "0.1.3"
+kdtree = "0.7.0"
 
 [lib]
 name = "pointpca2_rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate kiddo;
+extern crate kdtree;
 extern crate libm;
 extern crate nalgebra as na;
 extern crate ordered_float;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-extern crate kiddo;
+extern crate kdtree;
 extern crate libm;
 extern crate nalgebra as na;
 extern crate ordered_float;


### PR DESCRIPTION
Replace kiddo with kdtree, since kiddo needs a fixed bucket size and has problems with big sets of points with an equal value on an axis.

For information about this issue, see: https://github.com/sdd/kiddo/issues/78

This replacement improves the performance of knn search by about 40% as a high value for the bucket size is not needed anymore.