### PR TITLE
v1.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "pointpca2-rs"
 description = "An implementation of PointPCA2 in Rust"
-version = "1.3.0"
+version = "1.3.1"
 readme = "README.md"
 repository = "https://github.com/akaTsunemori/pointpca2-rs"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ To validate the accuracy and reliability of the Rust implementation, we conducte
 | 35      | 0.9987 | 1.0000 |
 | 36      | 1.0000 | 1.0000 |
 | 37      | 0.9999 | 1.0000 |
-| 38      | 0.9986 | 0.9999 |
+| 38      | 0.9987 | 0.9999 |
 | 39      | 0.9981 | 0.9999 |
-| 40      | 0.9646 | 0.9961 |
+| 40      | 0.9647 | 0.9961 |
 
 *Correlation coefficients rounded to 4 decimal places for better readability.*
 
@@ -118,11 +118,11 @@ We can also calculate the absolute differences between corresponding features an
 
 | Maximum absolute difference | Maximum standard deviation |
 |-----------------------------|----------------------------|
-| 0.11058533454473118         | 0.027662647255776825       |
+| 0.11058533454477848         | 0.027662635634742926       |
 
 Feature sets were derived from each implementation utilizing the entire dataset (refer to references). These features were partitioned into training and testing sets using Leave One Group Out. LazyPredict was employed to fit the training features to the subjective scores from the dataset using all available regressors. Pearson and Spearman correlation coefficients were computed to compare the predicted (test) scores and the subjective (reference) scores, and a comparative plot was generated to visualize the results.
 
-<img src="https://i.imgur.com/XKFmEbj.png">
+<img src="https://i.imgur.com/oaknzk7.png">
 </details>
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project features a Rust implementation of PointPCA2, designed for faster fe
 ## Roadmap
 - [x] Implementation: a fully working version of PointPCA2, written entirely in Rust
 - [x] Testing: extensively test the project on entire datasets
-- [x] Statistical comparison: compare the correlation between features generated from the orignal and Rust implementations
+- [x] Statistical comparison: compare the correlation between features generated from the original and Rust implementations
 
 ## Setup
 

--- a/src/eigenvectors.rs
+++ b/src/eigenvectors.rs
@@ -1,55 +1,32 @@
+use crate::utils;
 use na::DMatrix;
 
-fn svd_sign_correction(
-    mut u: DMatrix<f64>,
-    mut v: DMatrix<f64>,
-) -> (DMatrix<f64>, DMatrix<f64>) {
+fn svd_sign_correction(mut u: DMatrix<f64>, mut v: DMatrix<f64>) -> (DMatrix<f64>, DMatrix<f64>) {
     let nrows = v.nrows();
-    let ncols = v.ncols();
-    let mut max_abs_rows = vec![0; nrows];
+    let mut sign;
     for i in 0..nrows {
-        let mut max_abs_val = f64::NEG_INFINITY;
-        for j in 0..ncols {
-            let abs_val = v[(i, j)].abs();
-            if abs_val > max_abs_val {
-                max_abs_val = abs_val;
-                max_abs_rows[i] = j;
-            }
-        }
-    }
-    let signs: Vec<f64> = max_abs_rows
-        .iter()
-        .enumerate()
-        .map(|(i, &j)| v[(i, j)].signum())
-        .collect();
-    for i in 0..nrows {
-        for j in 0..ncols {
-            v[(i, j)] *= signs[i];
-            u[(j, i)] *= signs[i];
-        }
+        sign = v
+            .row(i)
+            .iter()
+            .max_by(|&&a, &&b| a.abs().total_cmp(&b.abs()))
+            .unwrap()
+            .signum();
+        v.row_mut(i).scale_mut(sign);
+        u.column_mut(i).scale_mut(sign);
     }
     (u, v)
 }
 
-fn compute_covariance_matrix<'a>(x: &'a DMatrix<f64>) -> DMatrix<f64> {
-    let nrows = x.nrows();
-    let ncols = x.ncols();
+fn compute_population_covariance(x: &DMatrix<f64>) -> DMatrix<f64> {
+    let nrows = x.nrows() as f64;
     let means = x.row_mean();
-    let mut covariance_matrix = DMatrix::<f64>::zeros(ncols, ncols);
-    for i in 0..ncols {
-        for j in 0..ncols {
-            let mut cov = 0.;
-            for k in 0..nrows {
-                cov += (x[(k, i)] - means[i]) * (x[(k, j)] - means[j]);
-            }
-            covariance_matrix[(i, j)] = cov / (nrows as f64 - 1.);
-        }
-    }
+    let centered = utils::subtract_row_from_matrix(&x, &means);
+    let covariance_matrix = (&centered.transpose() * &centered) / nrows;
     covariance_matrix
 }
 
 pub fn compute_eigenvectors<'a>(matrix: &'a DMatrix<f64>) -> DMatrix<f64> {
-    let covariance_matrix = compute_covariance_matrix(matrix);
+    let covariance_matrix = compute_population_covariance(matrix);
     let eigenvectors = covariance_matrix.svd(true, true);
     let u = eigenvectors.u.unwrap();
     let v_t = eigenvectors.v_t.unwrap();

--- a/src/eigenvectors.rs
+++ b/src/eigenvectors.rs
@@ -11,22 +11,23 @@ fn svd_sign_correction(mut u: DMatrix<f64>, mut v: DMatrix<f64>) -> (DMatrix<f64
             .max_by(|&&a, &&b| a.abs().total_cmp(&b.abs()))
             .unwrap()
             .signum();
-        v.row_mut(i).scale_mut(sign);
-        u.column_mut(i).scale_mut(sign);
+        v.row_mut(i).apply(|x| *x *= sign);
+        u.column_mut(i).apply(|x| *x *= sign);
     }
     (u, v)
 }
 
-fn compute_population_covariance(x: &DMatrix<f64>) -> DMatrix<f64> {
+fn compute_covariance_matrix(x: &DMatrix<f64>, unbiased: bool) -> DMatrix<f64> {
+    let bias = if unbiased { 1. } else { 0. };
     let nrows = x.nrows() as f64;
     let means = x.row_mean();
     let centered = utils::subtract_row_from_matrix(&x, &means);
-    let covariance_matrix = (&centered.transpose() * &centered) / nrows;
+    let covariance_matrix = (&centered.transpose() * &centered) / (nrows - bias);
     covariance_matrix
 }
 
 pub fn compute_eigenvectors<'a>(matrix: &'a DMatrix<f64>) -> DMatrix<f64> {
-    let covariance_matrix = compute_population_covariance(matrix);
+    let covariance_matrix = compute_covariance_matrix(matrix, false);
     let eigenvectors = covariance_matrix.svd(true, true);
     let u = eigenvectors.u.unwrap();
     let v_t = eigenvectors.v_t.unwrap();

--- a/src/features.rs
+++ b/src/features.rs
@@ -4,12 +4,12 @@ use na::DMatrix;
 use rayon::prelude::*;
 
 pub fn compute_features(
-    points_a: na::DMatrix<f64>,
-    colors_a: na::DMatrix<u8>,
-    points_b: na::DMatrix<f64>,
-    colors_b: na::DMatrix<u8>,
-    knn_indices_a: na::DMatrix<usize>,
-    knn_indices_b: na::DMatrix<usize>,
+    points_a: DMatrix<f64>,
+    colors_a: DMatrix<u8>,
+    points_b: DMatrix<f64>,
+    colors_b: DMatrix<u8>,
+    knn_indices_a: DMatrix<usize>,
+    knn_indices_b: DMatrix<usize>,
     search_size: usize,
 ) -> DMatrix<f64> {
     let nrows = points_a.nrows();
@@ -29,12 +29,11 @@ pub fn compute_features(
             // Principal components of reference data (new orthonormal basis)
             let eigenvectors_a = eigenvectors::compute_eigenvectors(&sl_points_a);
             // Project reference and distorted data onto the new orthonormal basis
+            let sl_points_a_mean = sl_points_a.row_mean();
             let projection_a_to_a =
-                utils::subtract_row_from_matrix(&sl_points_a, &sl_points_a.row_mean())
-                    * &eigenvectors_a;
+                utils::subtract_row_from_matrix(&sl_points_a, &sl_points_a_mean) * &eigenvectors_a;
             let projection_b_to_a =
-                utils::subtract_row_from_matrix(&sl_points_b, &sl_points_a.row_mean())
-                    * &eigenvectors_a;
+                utils::subtract_row_from_matrix(&sl_points_b, &sl_points_a_mean) * &eigenvectors_a;
             // Mean values for projected geometric data and texture data
             let mean_a = utils::concatenate_columns(&projection_a_to_a, &sl_colors_a).row_mean();
             let mean_b = utils::concatenate_columns(&projection_b_to_a, &sl_colors_b).row_mean();

--- a/src/features.rs
+++ b/src/features.rs
@@ -44,8 +44,8 @@ pub fn compute_features(
             let mean_deviation_a = utils::subtract_row_from_matrix(&proj_colors_a_concat, &mean_a);
             let mean_deviation_b = utils::subtract_row_from_matrix(&proj_colors_b_concat, &mean_b);
             // Variances and covariance
-            let variance_a = mean_deviation_a.map(|x| x * x).row_mean();
-            let variance_b = mean_deviation_b.map(|x| x * x).row_mean();
+            let variance_a = mean_deviation_a.map(|x| x.powi(2)).row_mean();
+            let variance_b = mean_deviation_b.map(|x| x.powi(2)).row_mean();
             let covariance_ab = mean_deviation_a.component_mul(&mean_deviation_b).row_mean();
             // Principal components of projected distorted data
             let eigenvectors_b = eigenvectors::compute_eigenvectors(&projection_b_to_a).transpose();

--- a/src/ply_manager.rs
+++ b/src/ply_manager.rs
@@ -1,4 +1,4 @@
-use nalgebra::DMatrix;
+use na::DMatrix;
 use ply_rs::{parser, ply, ply::DefaultElement, ply::Property};
 
 fn extract_value(property: &Property) -> f64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 extern crate ordered_float;
 use self::ordered_float::OrderedFloat;
-use nalgebra::{Const, DMatrix, Dyn, Matrix, Scalar, VecStorage};
+use na::{Const, DMatrix, Dyn, Matrix, Scalar, VecStorage};
 use std::ops::AddAssign;
 
 pub fn to_ordered(num: f64) -> OrderedFloat<f64> {
@@ -18,9 +18,9 @@ pub fn print_if_verbose<'a>(string: &'a str, verbose: &'a bool) {
 }
 
 pub fn slice_from_knn_indices<'a>(
-    points: &'a na::DMatrix<f64>,
-    colors: &'a na::DMatrix<u8>,
-    knn_indices: &'a na::DMatrix<usize>,
+    points: &'a DMatrix<f64>,
+    colors: &'a DMatrix<u8>,
+    knn_indices: &'a DMatrix<usize>,
     knn_row: usize,
     search_size: usize,
 ) -> (DMatrix<f64>, DMatrix<f64>) {


### PR DESCRIPTION
- To match pointpca2's behavior, the population covariance matrix is computed instead of the sample covariance matrix. An argument was added to make the possibility of easily swapping between the two covariance types.
- Overall polishing (mainly on eigenvectors.rs) to improve readability