### PR TITLE
v1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "pointpca2-rs"
 description = "An implementation of PointPCA2 in Rust"
-version = "1.3.1"
+version = "1.4.0"
 readme = "README.md"
 repository = "https://github.com/akaTsunemori/pointpca2-rs"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -46,56 +46,56 @@ fn main() {
 ```
 
 ## Validation
-To validate the accuracy and reliability of the Rust implementation, we conducted a feature-wise correlation analysis between the reference (original) implementation and the test (pointpca2-rs) implementation. Initially, the pointpca2 features were extracted from a comprehensive dataset (refer to references for dataset details) using both implementations. This procedure yielded a table comprising 40 columns, each representing a distinct feature, and 232 rows, corresponding to the number of point clouds in the dataset. Subsequently, the Pearson Correlation Coefficient (PCC) and the Spearman Ranking Order Correlation Coefficient (SROCC) were computed for each column, resulting in a correlation table with 40 rows, where each row pertains to the correlations of a specific feature, and three columns, indicating the feature index, PCC, and SROCC respectively.
+To validate the accuracy and reliability of the Rust implementation, we conducted a feature-wise correlation analysis between the reference (original) implementation and the test (pointpca2-rs) implementation. Initially, the pointpca2 features were extracted from a comprehensive dataset (refer to references for dataset details) using both implementations. This procedure yielded a table comprising 40 columns, each representing a distinct feature, and 232 rows, corresponding to the number of point clouds in the dataset. Subsequently, the Pearson Correlation Coefficient (PCC), the Spearman Ranking Order Correlation Coefficient (SROCC), the Mean Absolute Error (MAE), and the Mean Squared Error (MSE) were computed for each column, resulting in a correlation table with 40 rows, where each row pertains to the correlations of a specific feature, and five columns, indicating the feature index, PCC, SROCC, MAE, and MSE respectively.
 
 <details>
     <summary>Spoiler</summary>
 <br>
 
-| Feature | PLCC   | SROCC  |
-|---------|--------|--------|
-| 1       | 1.0000 | 1.0000 |
-| 2       | 1.0000 | 1.0000 |
-| 3       | 1.0000 | 1.0000 |
-| 4       | 1.0000 | 1.0000 |
-| 5       | 1.0000 | 1.0000 |
-| 6       | 1.0000 | 1.0000 |
-| 7       | 0.9968 | 0.9999 |
-| 8       | 0.9998 | 1.0000 |
-| 9       | 0.9999 | 1.0000 |
-| 10      | 1.0000 | 1.0000 |
-| 11      | 1.0000 | 1.0000 |
-| 12      | 1.0000 | 1.0000 |
-| 13      | 1.0000 | 1.0000 |
-| 14      | 0.9984 | 0.9998 |
-| 15      | 0.9993 | 0.9998 |
-| 16      | 0.9928 | 0.9989 |
-| 17      | 1.0000 | 0.9985 |
-| 18      | 1.0000 | 1.0000 |
-| 19      | 0.9991 | 0.9999 |
-| 20      | 0.9973 | 0.9998 |
-| 21      | 0.9618 | 0.9972 |
-| 22      | 0.9999 | 1.0000 |
-| 23      | 0.9997 | 1.0000 |
-| 24      | 0.9997 | 1.0000 |
-| 25      | 1.0000 | 1.0000 |
-| 26      | 1.0000 | 1.0000 |
-| 27      | 1.0000 | 1.0000 |
-| 28      | 0.8321 | 1.0000 |
-| 29      | 0.9367 | 1.0000 |
-| 30      | 0.9953 | 1.0000 |
-| 31      | 1.0000 | 1.0000 |
-| 32      | 1.0000 | 1.0000 |
-| 33      | 0.9999 | 1.0000 |
-| 34      | 0.9998 | 1.0000 |
-| 35      | 0.9987 | 1.0000 |
-| 36      | 1.0000 | 1.0000 |
-| 37      | 0.9999 | 1.0000 |
-| 38      | 0.9987 | 0.9999 |
-| 39      | 0.9981 | 0.9999 |
-| 40      | 0.9647 | 0.9961 |
+| Feature | PLCC   | SROCC  | MAE    | MSE    |
+|---------|--------|--------|--------|--------|
+| 1       | 1.0000 | 1.0000 | 0.0000 | 0.0000 |
+| 2       | 1.0000 | 1.0000 | 0.0000 | 0.0000 |
+| 3       | 1.0000 | 1.0000 | 0.0000 | 0.0000 |
+| 4       | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 5       | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 6       | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 7       | 0.9968 | 0.9999 | 0.0016 | 0.0000 |
+| 8       | 0.9998 | 1.0000 | 0.0005 | 0.0000 |
+| 9       | 0.9999 | 1.0000 | 0.0004 | 0.0000 |
+| 10      | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 11      | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 12      | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 13      | 1.0000 | 1.0000 | 0.0000 | 0.0000 |
+| 14      | 0.9984 | 0.9998 | 0.0070 | 0.0001 |
+| 15      | 0.9993 | 0.9998 | 0.0068 | 0.0002 |
+| 16      | 0.9928 | 0.9989 | 0.0134 | 0.0005 |
+| 17      | 1.0000 | 0.9985 | 0.0065 | 0.0000 |
+| 18      | 1.0000 | 1.0000 | 0.0003 | 0.0000 |
+| 19      | 0.9991 | 0.9999 | 0.0123 | 0.0003 |
+| 20      | 0.9973 | 0.9998 | 0.0066 | 0.0001 |
+| 21      | 0.9618 | 0.9972 | 0.0199 | 0.0012 |
+| 22      | 0.9999 | 1.0000 | 0.0026 | 0.0000 |
+| 23      | 0.9997 | 1.0000 | 0.0021 | 0.0000 |
+| 24      | 0.9997 | 1.0000 | 0.0007 | 0.0000 |
+| 25      | 1.0000 | 1.0000 | 0.0002 | 0.0000 |
+| 26      | 1.0000 | 1.0000 | 0.0002 | 0.0000 |
+| 27      | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 28      | 0.8321 | 1.0000 | 0.0013 | 0.0000 |
+| 29      | 0.9367 | 1.0000 | 0.0013 | 0.0000 |
+| 30      | 0.9953 | 1.0000 | 0.0016 | 0.0000 |
+| 31      | 1.0000 | 1.0000 | 0.0001 | 0.0000 |
+| 32      | 1.0000 | 1.0000 | 0.0002 | 0.0000 |
+| 33      | 0.9999 | 1.0000 | 0.0001 | 0.0000 |
+| 34      | 0.9998 | 1.0000 | 0.0004 | 0.0000 |
+| 35      | 0.9987 | 1.0000 | 0.0015 | 0.0000 |
+| 36      | 1.0000 | 1.0000 | 0.0002 | 0.0000 |
+| 37      | 0.9999 | 1.0000 | 0.0003 | 0.0000 |
+| 38      | 0.9987 | 0.9999 | 0.0010 | 0.0000 |
+| 39      | 0.9981 | 0.9999 | 0.0014 | 0.0000 |
+| 40      | 0.9647 | 0.9961 | 0.0032 | 0.0000 |
 
-*Correlation coefficients rounded to 4 decimal places for better readability.*
+*Values rounded to 4 decimal places for better readability.*
 
 </details>
 
@@ -112,7 +112,7 @@ Firstly, we can compare the average time taken for the computation of features f
 | Implementation | Average time taken (seconds) |
 |----------------|------------------------------|
 | MATLAB         | 140.1177001453079            |
-| pointpca2-rs   | 7.456929195543815            |
+| pointpca2-rs   | 6.681233939425699            |
 
 We can also calculate the absolute differences between corresponding features and then determine the maximum absolute difference. Additionally, we can compute the standard deviation of these absolute differences and find the highest standard deviation among them.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Firstly, we can compare the average time taken for the computation of features f
 | Implementation | Average time taken (seconds) |
 |----------------|------------------------------|
 | MATLAB         | 140.1177001453079            |
-| pointpca2-rs   | 6.681233939425699            |
+| pointpca2-rs   | 6.533299344366994            |
 
 We can also calculate the absolute differences between corresponding features and then determine the maximum absolute difference. Additionally, we can compute the standard deviation of these absolute differences and find the highest standard deviation among them.
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -20,7 +20,6 @@ pub fn compute_features(
     let nrows = points_a.len();
     let ncols = 42;
     let mut local_features = DMatrix::zeros(nrows, ncols);
-    local_features.fill(f64::NAN);
     local_features
         .row_iter_mut()
         .collect::<Vec<_>>()

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,31 +1,39 @@
 use crate::eigenvectors;
+use crate::knn_search;
 use crate::utils;
 use na::DMatrix;
-use rayon::prelude::*;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
 pub fn compute_features(
     points_a: DMatrix<f64>,
     colors_a: DMatrix<u8>,
     points_b: DMatrix<f64>,
     colors_b: DMatrix<u8>,
-    knn_indices_a: DMatrix<usize>,
-    knn_indices_b: DMatrix<usize>,
     search_size: usize,
 ) -> DMatrix<f64> {
-    let nrows = points_a.nrows();
+    let points_a = utils::dmatrix_to_vec_f64(points_a);
+    let colors_a = utils::dmatrix_to_vec_f64(colors_a);
+    let points_b = utils::dmatrix_to_vec_f64(points_b);
+    let colors_b = utils::dmatrix_to_vec_f64(colors_b);
+    let kd_tree_a = knn_search::build_tree(&points_a);
+    let kd_tree_b = knn_search::build_tree(&points_b);
+    let nrows = points_a.len();
     let ncols = 42;
     let mut local_features = DMatrix::zeros(nrows, ncols);
     local_features.fill(f64::NAN);
-    let mut local_features_rows: Vec<_> = local_features.row_iter_mut().collect();
-    local_features_rows
+    local_features
+        .row_iter_mut()
+        .collect::<Vec<_>>()
         .par_iter_mut()
         .enumerate()
         .for_each(|(i, row)| {
+            let knn_indices_a = knn_search::nearest_n(&kd_tree_a, &points_a[i], search_size);
+            let knn_indices_b = knn_search::nearest_n(&kd_tree_b, &points_a[i], search_size);
             // Slice points and colors from their respective knn indices
             let (sl_points_a, sl_colors_a) =
-                utils::slice_from_knn_indices(&points_a, &colors_a, &knn_indices_a, i, search_size);
+                utils::slice_from_knn_indices(&points_a, &colors_a, &knn_indices_a, search_size);
             let (sl_points_b, sl_colors_b) =
-                utils::slice_from_knn_indices(&points_b, &colors_b, &knn_indices_b, i, search_size);
+                utils::slice_from_knn_indices(&points_b, &colors_b, &knn_indices_b, search_size);
             // Principal components of reference data (new orthonormal basis)
             let eigenvectors_a = eigenvectors::compute_eigenvectors(&sl_points_a);
             // Project reference and distorted data onto the new orthonormal basis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ mod eigenvectors;
 mod features;
 mod knn_search;
 pub mod ply_manager;
-mod pooling;
 mod predictors;
 mod preprocessing;
 mod spatial_metrics;
@@ -36,7 +35,5 @@ pub fn compute_pointpca2<'a>(
     );
     utils::print_if_verbose("Computing predictors", &verbose);
     let predictors_result = predictors::compute_predictors(local_features);
-    utils::print_if_verbose("Pooling predictors", &verbose);
-    let pooled_predictors = pooling::mean_pooling(predictors_result);
-    pooled_predictors
+    predictors_result
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,17 +26,12 @@ pub fn compute_pointpca2<'a>(
     utils::print_if_verbose("Preprocessing", &verbose);
     let (points_a, colors_a) = preprocessing::preprocess_point_cloud(&points_a, &colors_a);
     let (points_b, colors_b) = preprocessing::preprocess_point_cloud(&points_b, &colors_b);
-    utils::print_if_verbose("Performing knn search", &verbose);
-    let knn_indices_a = knn_search::knn_search(&points_a, &points_a, search_size);
-    let knn_indices_b = knn_search::knn_search(&points_b, &points_a, search_size);
     utils::print_if_verbose("Computing local features", &verbose);
     let local_features = features::compute_features(
         points_a,
         colors_a,
         points_b,
         colors_b,
-        knn_indices_a,
-        knn_indices_b,
         search_size,
     );
     utils::print_if_verbose("Computing predictors", &verbose);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod eigenvectors;
 mod features;
 mod knn_search;
 pub mod ply_manager;
+mod pooling;
 mod predictors;
 mod preprocessing;
 mod spatial_metrics;
@@ -26,13 +27,8 @@ pub fn compute_pointpca2<'a>(
     let (points_a, colors_a) = preprocessing::preprocess_point_cloud(&points_a, &colors_a);
     let (points_b, colors_b) = preprocessing::preprocess_point_cloud(&points_b, &colors_b);
     utils::print_if_verbose("Computing local features", &verbose);
-    let local_features = features::compute_features(
-        points_a,
-        colors_a,
-        points_b,
-        colors_b,
-        search_size,
-    );
+    let local_features =
+        features::compute_features(points_a, colors_a, points_b, colors_b, search_size);
     utils::print_if_verbose("Computing predictors", &verbose);
     let predictors_result = predictors::compute_predictors(local_features);
     predictors_result

--- a/src/pooling.rs
+++ b/src/pooling.rs
@@ -1,0 +1,44 @@
+use na::{DMatrix, Matrix1xX};
+
+enum PoolingTechnique {
+    MeanPooling,
+    MaxPooling,
+}
+
+impl PoolingTechnique {
+    fn from_str(pooling: &str) -> Option<Self> {
+        match pooling {
+            "mean_pooling" => Some(Self::MeanPooling),
+            "max_pooling" => Some(Self::MaxPooling),
+            _ => None,
+        }
+    }
+}
+
+pub struct Pool {
+    technique: PoolingTechnique,
+}
+
+impl Pool {
+    pub fn new(pooling: &str) -> Option<Self> {
+        PoolingTechnique::from_str(pooling).map(|technique| Self { technique })
+    }
+
+    pub fn pool<'a>(&self, matrix: &'a DMatrix<f64>) -> Matrix1xX<f64> {
+        match self.technique {
+            PoolingTechnique::MeanPooling => self.mean_pooling(matrix),
+            PoolingTechnique::MaxPooling => self.max_pooling(matrix),
+        }
+    }
+
+    fn mean_pooling<'a>(&self, matrix: &'a DMatrix<f64>) -> Matrix1xX<f64> {
+        matrix.row_mean()
+    }
+
+    fn max_pooling<'a>(&self, matrix: &'a DMatrix<f64>) -> Matrix1xX<f64> {
+        (0..matrix.ncols())
+            .map(|i| matrix.column(i).max())
+            .collect::<Vec<_>>()
+            .into()
+    }
+}

--- a/src/pooling.rs
+++ b/src/pooling.rs
@@ -1,6 +1,0 @@
-use na::{DMatrix, Matrix1xX};
-
-pub fn mean_pooling(predictors: DMatrix<f64>) -> Matrix1xX<f64> {
-    let pooled_predictors = predictors.row_mean();
-    pooled_predictors
-}

--- a/src/predictors.rs
+++ b/src/predictors.rs
@@ -1,3 +1,4 @@
+use crate::pooling;
 use crate::spatial_metrics;
 use na::{DMatrix, Matrix1xX};
 
@@ -17,149 +18,166 @@ pub fn compute_predictors(local_features: DMatrix<f64>) -> Matrix1xX<f64> {
     let eigenvectors_b_y = local_features.columns(36, 3);
     let eigenvectors_b_z = local_features.columns(39, 3);
     let mut predictors = Matrix1xX::zeros(40);
+    let pooling = pooling::Pool::new("mean_pooling").unwrap();
     /*
         Textural predictors
     */
     // Relative differences in mean color values
-    predictors.columns_mut(0, 3).copy_from(
-        &spatial_metrics::iter_relative_difference(&colors_mean_a, &colors_mean_b).row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::iter_relative_difference(
+        &colors_mean_a,
+        &colors_mean_b,
+    ));
+    predictors.columns_mut(0, 3).copy_from(&pooled_predictor);
     // Relative differences in color variances
-    predictors.columns_mut(3, 3).copy_from(
-        &spatial_metrics::iter_relative_difference(&colors_variance_a, &colors_variance_b)
-            .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::iter_relative_difference(
+        &colors_variance_a,
+        &colors_variance_b,
+    ));
+    predictors.columns_mut(3, 3).copy_from(&pooled_predictor);
     // Covariance differences between color variances
-    predictors.columns_mut(6, 3).copy_from(
-        &spatial_metrics::covariance_differences(
-            &colors_variance_a,
-            &colors_variance_b,
-            &colors_covariance_ab,
-        )
-        .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::covariance_differences(
+        &colors_variance_a,
+        &colors_variance_b,
+        &colors_covariance_ab,
+    ));
+    predictors.columns_mut(6, 3).copy_from(&pooled_predictor);
     // Sum of variances of textures
-    predictors.column_mut(9).copy_from(
-        &spatial_metrics::textural_variance_sum(&colors_variance_a, &colors_variance_b).row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::textural_variance_sum(
+        &colors_variance_a,
+        &colors_variance_b,
+    ));
+    predictors.column_mut(9).copy_from(&pooled_predictor);
     // Relative differences in omnivariance of textures
-    predictors.column_mut(10).copy_from(
-        &spatial_metrics::omnivariance_differences(&colors_variance_a, &colors_variance_b)
-            .row_mean(),
-    );
+
+    let pooled_predictor = pooling.pool(&spatial_metrics::omnivariance_differences(
+        &colors_variance_a,
+        &colors_variance_b,
+    ));
+    predictors.column_mut(10).copy_from(&pooled_predictor);
     // Entropy of textures
-    predictors
-        .column_mut(11)
-        .copy_from(&spatial_metrics::entropy(&colors_variance_a, &colors_variance_b).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::entropy(
+        &colors_variance_a,
+        &colors_variance_b,
+    ));
+    predictors.column_mut(11).copy_from(&pooled_predictor);
     /*
         Geometric predictors
     */
     // Euclidean distances between distorted and reference points (error vector)
-    predictors.column_mut(12).copy_from(
-        &spatial_metrics::euclidean_distances(&projection_a_to_a, &projection_b_to_a).row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::euclidean_distances(
+        &projection_a_to_a,
+        &projection_b_to_a,
+    ));
+    predictors.column_mut(12).copy_from(&pooled_predictor);
     // Projected distances of vectors between distorted and reference points from reference planes
-    predictors.column_mut(13).copy_from(
-        &spatial_metrics::vector_projected_distances(&projection_a_to_a, &projection_b_to_a, 0)
-            .row_mean(),
-    );
-    predictors.column_mut(14).copy_from(
-        &spatial_metrics::vector_projected_distances(&projection_a_to_a, &projection_b_to_a, 1)
-            .row_mean(),
-    );
-    predictors.column_mut(15).copy_from(
-        &spatial_metrics::vector_projected_distances(&projection_a_to_a, &projection_b_to_a, 2)
-            .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::vector_projected_distances(
+        &projection_a_to_a,
+        &projection_b_to_a,
+        0,
+    ));
+    predictors.column_mut(13).copy_from(&pooled_predictor);
+    let pooled_predictor = pooling.pool(&spatial_metrics::vector_projected_distances(
+        &projection_a_to_a,
+        &projection_b_to_a,
+        1,
+    ));
+    predictors.column_mut(14).copy_from(&pooled_predictor);
+    let pooled_predictor = pooling.pool(&spatial_metrics::vector_projected_distances(
+        &projection_a_to_a,
+        &projection_b_to_a,
+        2,
+    ));
+    predictors.column_mut(15).copy_from(&pooled_predictor);
     // Projected distances of reference points from reference planes
-    predictors
-        .columns_mut(16, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(&projection_a_to_a).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::point_projected_distances(
+        &projection_a_to_a,
+    ));
+    predictors.columns_mut(16, 2).copy_from(&pooled_predictor);
     // Euclidean distances between distorted points and reference centroids
-    predictors
-        .column_mut(18)
-        .copy_from(&spatial_metrics::point_to_centroid_distances(&projection_b_to_a).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::point_to_centroid_distances(
+        &projection_b_to_a,
+    ));
+    predictors.column_mut(18).copy_from(&pooled_predictor);
     // Projected distances of distorted points from reference planes
-    predictors
-        .columns_mut(19, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(&projection_b_to_a).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::point_projected_distances(
+        &projection_b_to_a,
+    ));
+    predictors.columns_mut(19, 2).copy_from(&pooled_predictor);
     // Euclidean distances between distorted centroids and reference centroids
-    predictors
-        .column_mut(21)
-        .copy_from(&spatial_metrics::point_to_centroid_distances(&points_mean_b).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::point_to_centroid_distances(
+        &points_mean_b,
+    ));
+    predictors.column_mut(21).copy_from(&pooled_predictor);
     // Projected distances of distorted centroids from reference planes
-    predictors
-        .columns_mut(22, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(&points_mean_b).row_mean());
+    let pooled_predictor =
+        pooling.pool(&spatial_metrics::point_projected_distances(&points_mean_b));
+    predictors.columns_mut(22, 2).copy_from(&pooled_predictor);
     // Relative differences in points variances
-    predictors.columns_mut(24, 3).copy_from(
-        &spatial_metrics::iter_relative_difference(&points_variance_a, &points_variance_b)
-            .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::iter_relative_difference(
+        &points_variance_a,
+        &points_variance_b,
+    ));
+    predictors.columns_mut(24, 3).copy_from(&pooled_predictor);
     // Covariance differences between points variances
-    predictors.columns_mut(27, 3).copy_from(
-        &spatial_metrics::covariance_differences(
-            &points_variance_a,
-            &points_variance_b,
-            &points_covariance_ab,
-        )
-        .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::covariance_differences(
+        &points_variance_a,
+        &points_variance_b,
+        &points_covariance_ab,
+    ));
+    predictors.columns_mut(27, 3).copy_from(&pooled_predictor);
     // Relative difference in omnivariance of points
-    predictors.column_mut(30).copy_from(
-        &spatial_metrics::omnivariance_differences(&points_variance_a, &points_variance_b)
-            .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::omnivariance_differences(
+        &points_variance_a,
+        &points_variance_b,
+    ));
+    predictors.column_mut(30).copy_from(&pooled_predictor);
     // Entropy of points
-    predictors
-        .column_mut(31)
-        .copy_from(&spatial_metrics::entropy(&points_variance_a, &points_variance_b).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::entropy(
+        &points_variance_a,
+        &points_variance_b,
+    ));
+    predictors.column_mut(31).copy_from(&pooled_predictor);
     // Relative differences in anisotropy, planarity, and linearity of points
-    predictors.column_mut(32).copy_from(
-        &spatial_metrics::anisotropy_planarity_linearity(
-            &points_variance_a,
-            &points_variance_b,
-            0,
-            2,
-        )
-        .row_mean(),
-    );
-    predictors.column_mut(33).copy_from(
-        &spatial_metrics::anisotropy_planarity_linearity(
-            &points_variance_a,
-            &points_variance_b,
-            1,
-            2,
-        )
-        .row_mean(),
-    );
-    predictors.column_mut(34).copy_from(
-        &spatial_metrics::anisotropy_planarity_linearity(
-            &points_variance_a,
-            &points_variance_b,
-            0,
-            1,
-        )
-        .row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::anisotropy_planarity_linearity(
+        &points_variance_a,
+        &points_variance_b,
+        0,
+        2,
+    ));
+    predictors.column_mut(32).copy_from(&pooled_predictor);
+    let pooled_predictor = pooling.pool(&spatial_metrics::anisotropy_planarity_linearity(
+        &points_variance_a,
+        &points_variance_b,
+        1,
+        2,
+    ));
+    predictors.column_mut(33).copy_from(&pooled_predictor);
+    let pooled_predictor = pooling.pool(&spatial_metrics::anisotropy_planarity_linearity(
+        &points_variance_a,
+        &points_variance_b,
+        0,
+        1,
+    ));
+    predictors.column_mut(34).copy_from(&pooled_predictor);
     // Relative differences in surface variation of points
-    predictors.column_mut(35).copy_from(
-        &spatial_metrics::surface_variation(&points_variance_a, &points_variance_b).row_mean(),
-    );
+    let pooled_predictor = pooling.pool(&spatial_metrics::surface_variation(
+        &points_variance_a,
+        &points_variance_b,
+    ));
+    predictors.column_mut(35).copy_from(&pooled_predictor);
     // Relative differences in sphericity of points
-    predictors
-        .column_mut(36)
-        .copy_from(&spatial_metrics::sphericity(&points_variance_a, &points_variance_b).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::sphericity(
+        &points_variance_a,
+        &points_variance_b,
+    ));
+    predictors.column_mut(36).copy_from(&pooled_predictor);
     // Angular similarity between distorted and reference planes
-    predictors
-        .column_mut(37)
-        .copy_from(&spatial_metrics::angular_similarity(&eigenvectors_b_y).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::angular_similarity(&eigenvectors_b_y));
+    predictors.column_mut(37).copy_from(&pooled_predictor);
     // Parallelity of distorted planes
-    predictors
-        .column_mut(38)
-        .copy_from(&spatial_metrics::parallelity(&eigenvectors_b_x, 0).row_mean());
-    predictors
-        .column_mut(39)
-        .copy_from(&spatial_metrics::parallelity(&eigenvectors_b_z, 2).row_mean());
+    let pooled_predictor = pooling.pool(&spatial_metrics::parallelity(&eigenvectors_b_x, 0));
+    predictors.column_mut(38).copy_from(&pooled_predictor);
+    let pooled_predictor = pooling.pool(&spatial_metrics::parallelity(&eigenvectors_b_z, 2));
+    predictors.column_mut(39).copy_from(&pooled_predictor);
     predictors
 }

--- a/src/predictors.rs
+++ b/src/predictors.rs
@@ -23,186 +23,133 @@ pub fn compute_predictors(local_features: DMatrix<f64>) -> DMatrix<f64> {
         Textural predictors
     */
     // Relative differences in mean color values
-    predictors
-        .columns_mut(0, 3)
-        .copy_from(&spatial_metrics::iter_relative_difference(
-            &colors_mean_a,
-            &colors_mean_b,
-        ));
+    spatial_metrics::iter_relative_difference(
+        &colors_mean_a,
+        &colors_mean_b,
+        &mut predictors.columns_mut(0, 3),
+    );
     // Relative differences in color variances
-    predictors
-        .columns_mut(3, 3)
-        .copy_from(&spatial_metrics::iter_relative_difference(
-            &colors_variance_a,
-            &colors_variance_b,
-        ));
+    spatial_metrics::iter_relative_difference(
+        &colors_variance_a,
+        &colors_variance_b,
+        &mut predictors.columns_mut(3, 3),
+    );
     // Covariance differences between color variances
-    predictors
-        .columns_mut(6, 3)
-        .copy_from(&spatial_metrics::covariance_differences(
-            &colors_variance_a,
-            &colors_variance_b,
-            &colors_covariance_ab,
-        ));
+    spatial_metrics::covariance_differences(
+        &colors_variance_a,
+        &colors_variance_b,
+        &colors_covariance_ab,
+        &mut predictors.columns_mut(6, 3),
+    );
     // Sum of variances of textures
-    predictors
-        .column_mut(9)
-        .copy_from(&spatial_metrics::textural_variance_sum(
-            &colors_variance_a,
-            &colors_variance_b,
-        ));
+    spatial_metrics::textural_variance_sum(
+        &colors_variance_a,
+        &colors_variance_b,
+        &mut predictors.columns_mut(9, 1),
+    );
     // Relative differences in omnivariance of textures
-    predictors
-        .column_mut(10)
-        .copy_from(&spatial_metrics::omnivariance_differences(
-            &colors_variance_a,
-            &colors_variance_b,
-        ));
+    spatial_metrics::omnivariance_differences(
+        &colors_variance_a,
+        &colors_variance_b,
+        &mut predictors.columns_mut(10, 1),
+    );
     // Entropy of textures
-    predictors
-        .column_mut(11)
-        .copy_from(&spatial_metrics::entropy(
-            &colors_variance_a,
-            &colors_variance_b,
-        ));
+    spatial_metrics::entropy(
+        &colors_variance_a,
+        &colors_variance_b,
+        &mut predictors.columns_mut(11, 1),
+    );
     /*
         Geometric predictors
     */
     // Euclidean distances between distorted and reference points (error vector)
-    predictors
-        .column_mut(12)
-        .copy_from(&spatial_metrics::euclidean_distances(
-            &projection_a_to_a,
-            &projection_b_to_a,
-        ));
+    spatial_metrics::euclidean_distances(
+        &projection_a_to_a,
+        &projection_b_to_a,
+        &mut predictors.columns_mut(12, 1),
+    );
     // Projected distances of vectors between distorted and reference points from reference planes
-    predictors
-        .column_mut(13)
-        .copy_from(&spatial_metrics::vector_projected_distances(
+    for i in 0..3 {
+        spatial_metrics::vector_projected_distances(
             &projection_a_to_a,
             &projection_b_to_a,
-            0,
-        ));
-    predictors
-        .column_mut(14)
-        .copy_from(&spatial_metrics::vector_projected_distances(
-            &projection_a_to_a,
-            &projection_b_to_a,
-            1,
-        ));
-    predictors
-        .column_mut(15)
-        .copy_from(&spatial_metrics::vector_projected_distances(
-            &projection_a_to_a,
-            &projection_b_to_a,
-            2,
-        ));
+            i,
+            &mut predictors.columns_mut(13 + i, 1),
+        );
+    }
     // Projected distances of reference points from reference planes
-    predictors
-        .columns_mut(16, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(
-            &projection_a_to_a,
-        ));
+    spatial_metrics::point_projected_distances(
+        &projection_a_to_a,
+        &mut predictors.columns_mut(16, 2),
+    );
     // Euclidean distances between distorted points and reference centroids
-    predictors
-        .column_mut(18)
-        .copy_from(&spatial_metrics::point_to_centroid_distances(
-            &projection_b_to_a,
-        ));
+    spatial_metrics::point_to_centroid_distances(
+        &projection_b_to_a,
+        &mut predictors.columns_mut(18, 1),
+    );
     // Projected distances of distorted points from reference planes
-    predictors
-        .columns_mut(19, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(
-            &projection_b_to_a,
-        ));
+    spatial_metrics::point_projected_distances(
+        &projection_b_to_a,
+        &mut predictors.columns_mut(19, 2),
+    );
     // Euclidean distances between distorted centroids and reference centroids
-    predictors
-        .column_mut(21)
-        .copy_from(&spatial_metrics::point_to_centroid_distances(
-            &points_mean_b,
-        ));
+    spatial_metrics::point_to_centroid_distances(
+        &points_mean_b,
+        &mut predictors.columns_mut(21, 1),
+    );
     // Projected distances of distorted centroids from reference planes
-    predictors
-        .columns_mut(22, 2)
-        .copy_from(&spatial_metrics::point_projected_distances(&points_mean_b));
+    spatial_metrics::point_projected_distances(&points_mean_b, &mut predictors.columns_mut(22, 2));
     // Relative differences in points variances
-    predictors
-        .columns_mut(24, 3)
-        .copy_from(&spatial_metrics::iter_relative_difference(
-            &points_variance_a,
-            &points_variance_b,
-        ));
+    spatial_metrics::iter_relative_difference(
+        &points_variance_a,
+        &points_variance_b,
+        &mut predictors.columns_mut(24, 3),
+    );
     // Covariance differences between points variances
-    predictors
-        .columns_mut(27, 3)
-        .copy_from(&spatial_metrics::covariance_differences(
-            &points_variance_a,
-            &points_variance_b,
-            &points_covariance_ab,
-        ));
+    spatial_metrics::covariance_differences(
+        &points_variance_a,
+        &points_variance_b,
+        &points_covariance_ab,
+        &mut predictors.columns_mut(27, 3),
+    );
     // Relative difference in omnivariance of points
-    predictors
-        .column_mut(30)
-        .copy_from(&spatial_metrics::omnivariance_differences(
-            &points_variance_a,
-            &points_variance_b,
-        ));
+    spatial_metrics::omnivariance_differences(
+        &points_variance_a,
+        &points_variance_b,
+        &mut predictors.columns_mut(30, 1),
+    );
     // Entropy of points
-    predictors
-        .column_mut(31)
-        .copy_from(&spatial_metrics::entropy(
-            &points_variance_a,
-            &points_variance_b,
-        ));
+    spatial_metrics::entropy(
+        &points_variance_a,
+        &points_variance_b,
+        &mut predictors.columns_mut(31, 1),
+    );
     // Relative differences in anisotropy, planarity, and linearity of points
-    predictors
-        .column_mut(32)
-        .copy_from(&spatial_metrics::anisotropy_planarity_linearity(
+    for (i, col1, col2) in [(0, 0, 2), (1, 1, 2), (2, 0, 1)] {
+        spatial_metrics::anisotropy_planarity_linearity(
             &points_variance_a,
             &points_variance_b,
-            0,
-            2,
-        ));
-    predictors
-        .column_mut(33)
-        .copy_from(&spatial_metrics::anisotropy_planarity_linearity(
-            &points_variance_a,
-            &points_variance_b,
-            1,
-            2,
-        ));
-    predictors
-        .column_mut(34)
-        .copy_from(&spatial_metrics::anisotropy_planarity_linearity(
-            &points_variance_a,
-            &points_variance_b,
-            0,
-            1,
-        ));
+            col1,
+            col2,
+            &mut predictors.columns_mut(32 + i, 1),
+        );
+    }
     // Relative differences in surface variation of points
-    predictors
-        .column_mut(35)
-        .copy_from(&spatial_metrics::surface_variation(
-            &points_variance_a,
-            &points_variance_b,
-        ));
+    spatial_metrics::surface_variation(
+        &points_variance_a,
+        &points_variance_b,
+        &mut predictors.columns_mut(35, 1),
+    );
     // Relative differences in sphericity of points
-    predictors
-        .column_mut(36)
-        .copy_from(&spatial_metrics::sphericity(
-            &points_variance_a,
-            &points_variance_b,
-        ));
+    spatial_metrics::sphericity(
+        &points_variance_a,
+        &points_variance_b,
+        &mut predictors.columns_mut(36, 1),
+    );
     // Angular similarity between distorted and reference planes
-    predictors
-        .column_mut(37)
-        .copy_from(&spatial_metrics::angular_similarity(&eigenvectors_b_y));
+    spatial_metrics::angular_similarity(&eigenvectors_b_y, &mut predictors.columns_mut(37, 1));
     // Parallelity of distorted planes
-    predictors
-        .column_mut(38)
-        .copy_from(&spatial_metrics::parallelity(&eigenvectors_b_x, 0));
-    predictors
-        .column_mut(39)
-        .copy_from(&spatial_metrics::parallelity(&eigenvectors_b_z, 2));
+    spatial_metrics::parallelity(&eigenvectors_b_x, 0, &mut predictors.columns_mut(38, 1));
+    spatial_metrics::parallelity(&eigenvectors_b_z, 2, &mut predictors.columns_mut(39, 1));
     predictors
 }

--- a/src/spatial_metrics.rs
+++ b/src/spatial_metrics.rs
@@ -1,7 +1,7 @@
 use libm::acos;
-use na::{DMatrix, MatrixView};
+use na::{MatrixView, MatrixViewMut};
 use num_traits::Pow;
-use std::{f64::consts::PI, f64::EPSILON};
+use std::f64::{consts::PI, EPSILON};
 
 pub fn relative_difference(x: f64, y: f64) -> f64 {
     1. - (x - y).abs() / (x.abs() + y.abs() + EPSILON)
@@ -10,77 +10,67 @@ pub fn relative_difference(x: f64, y: f64) -> f64 {
 pub fn iter_relative_difference<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
     let ncols = x.ncols();
-    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         for j in 0..ncols {
-            result[(i, j)] = relative_difference(x[(i, j)], y[(i, j)]);
+            target[(i, j)] = relative_difference(x[(i, j)], y[(i, j)]);
         }
     }
-    result
 }
 
 pub fn covariance_differences<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
     z: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
-    assert_eq!(x.shape(), z.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
     let ncols = x.ncols();
-    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         for j in 0..ncols {
             let sqrt_product_diff = (x[(i, j)].sqrt() * y[(i, j)].sqrt() - z[(i, j)]).abs();
             let sqrt_product_norm = x[(i, j)].sqrt() * y[(i, j)].sqrt() + EPSILON;
-            result[(i, j)] = sqrt_product_diff / sqrt_product_norm;
+            target[(i, j)] = sqrt_product_diff / sqrt_product_norm;
         }
     }
-    result
 }
 
 pub fn textural_variance_sum<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_sum: f64 = x.row(i).sum();
         let y_sum: f64 = y.row(i).sum();
-        result[(i, 0)] = relative_difference(x_sum, y_sum);
+        target[(i, 0)] = relative_difference(x_sum, y_sum);
     }
-    result
 }
 
 pub fn omnivariance_differences<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_prod: f64 = x.row(i).product();
         let y_prod: f64 = y.row(i).product();
-        result[(i, 0)] = relative_difference(x_prod.cbrt(), y_prod.cbrt());
+        target[(i, 0)] = relative_difference(x_prod.cbrt(), y_prod.cbrt());
     }
-    result
 }
 
 pub fn entropy<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
     let ncols = x.ncols();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let mut x_entropy: f64 = 0.;
         let mut y_entropy: f64 = 0.;
@@ -88,67 +78,61 @@ pub fn entropy<'a, T: na::Dim>(
             x_entropy += x[(i, j)] * (x[(i, j)] + EPSILON).ln();
             y_entropy += y[(i, j)] * (y[(i, j)] + EPSILON).ln();
         }
-        result[(i, 0)] = relative_difference(x_entropy, y_entropy);
+        target[(i, 0)] = relative_difference(x_entropy, y_entropy);
     }
-    result
 }
 
 pub fn euclidean_distances<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
     let ncols = x.ncols();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let mut dists: f64 = 0.;
         for j in 0..ncols {
             dists += (x[(i, j)] - y[(i, j)]).pow(2);
         }
-        result[(i, 0)] = dists.sqrt();
+        target[(i, 0)] = dists.sqrt();
     }
-    result
 }
 
 pub fn vector_projected_distances<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
     col: usize,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
-    let ncols = 1;
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
-        result[(i, 0)] = (x[(i, col)] - y[(i, col)]).abs();
+        target[(i, 0)] = (x[(i, col)] - y[(i, col)]).abs();
     }
-    result
 }
 
-pub fn point_projected_distances<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
-    let ncols = 2;
+pub fn point_projected_distances<'a, T: na::Dim>(
+    x: &'a MatrixView<f64, T, T>,
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
-        result[(i, 0)] = x[(i, 1)].abs();
-        result[(i, 1)] = x[(i, 2)].abs();
+        target[(i, 0)] = x[(i, 1)].abs();
+        target[(i, 1)] = x[(i, 2)].abs();
     }
-    result
 }
 
-pub fn point_to_centroid_distances<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
-    let ncols = 1;
+pub fn point_to_centroid_distances<'a, T: na::Dim>(
+    x: &'a MatrixView<f64, T, T>,
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         let mut dists: f64 = 0.;
         for j in 0..x.ncols() {
             dists += x[(i, j)].pow(2);
         }
-        result[(i, 0)] = dists.sqrt();
+        target[(i, 0)] = dists.sqrt();
     }
-    result
 }
 
 pub fn anisotropy_planarity_linearity<'a, T: na::Dim>(
@@ -156,68 +140,64 @@ pub fn anisotropy_planarity_linearity<'a, T: na::Dim>(
     y: &'a MatrixView<f64, T, T>,
     col1: usize,
     col2: usize,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_diff = (x[(i, col1)] - x[(i, col2)]) / (x[(i, 0)] + EPSILON);
         let y_diff = (y[(i, col1)] - y[(i, col2)]) / (y[(i, 0)] + EPSILON);
-        result[(i, 0)] = relative_difference(x_diff, y_diff);
+        target[(i, 0)] = relative_difference(x_diff, y_diff);
     }
-    result
 }
 
 pub fn surface_variation<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_sum: f64 = x.row(i).sum();
         let y_sum: f64 = y.row(i).sum();
-        result[(i, 0)] =
+        target[(i, 0)] =
             relative_difference(x[(i, 2)] / (x_sum + EPSILON), y[(i, 2)] / (y_sum + EPSILON));
     }
-    result
 }
 
 pub fn sphericity<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-) -> DMatrix<f64> {
-    assert_eq!(x.shape(), y.shape(), "Matrices must have the same shape.");
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
-        result[(i, 0)] = relative_difference(
+        target[(i, 0)] = relative_difference(
             x[(i, 2)] / (x[(i, 0)] + EPSILON),
             y[(i, 2)] / (y[(i, 0)] + EPSILON),
         );
     }
-    result
 }
 
-pub fn angular_similarity<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
+pub fn angular_similarity<'a, T: na::Dim>(
+    x: &'a MatrixView<f64, T, T>,
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let numerator = x[(i, 1)];
         let (mut a, mut b, mut c) = (x[(i, 0)], x[(i, 1)], x[(i, 2)]);
         (a, b, c) = (a.pow(2), b.pow(2), c.pow(2));
         let denominator: f64 = (a + b + c).sqrt() + EPSILON;
-        result[(i, 0)] = 1. - 2. * acos((numerator / denominator).abs()) / PI;
+        target[(i, 0)] = 1. - 2. * acos((numerator / denominator).abs()) / PI;
     }
-    result
 }
 
-pub fn parallelity<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>, col: usize) -> DMatrix<f64> {
-    let nrows = x.nrows();
-    let mut result = DMatrix::zeros(nrows, 1);
+pub fn parallelity<'a, T: na::Dim>(
+    x: &'a MatrixView<f64, T, T>,
+    col: usize,
+    target: &'a mut MatrixViewMut<f64, T, T>,
+) {
     for (i, num) in x.column(col).iter().enumerate() {
-        result[i] = 1. - *num;
+        target[i] = 1. - *num;
     }
-    result
 }

--- a/src/spatial_metrics.rs
+++ b/src/spatial_metrics.rs
@@ -1,7 +1,7 @@
 use libm::acos;
-use na::{MatrixView, MatrixViewMut};
+use na::{DMatrix, MatrixView};
 use num_traits::Pow;
-use std::f64::{consts::PI, EPSILON};
+use std::{f64::consts::PI, f64::EPSILON};
 
 pub fn relative_difference(x: f64, y: f64) -> f64 {
     1. - (x - y).abs() / (x.abs() + y.abs() + EPSILON)
@@ -10,67 +10,71 @@ pub fn relative_difference(x: f64, y: f64) -> f64 {
 pub fn iter_relative_difference<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
     let ncols = x.ncols();
+    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         for j in 0..ncols {
-            target[(i, j)] = relative_difference(x[(i, j)], y[(i, j)]);
+            result[(i, j)] = relative_difference(x[(i, j)], y[(i, j)]);
         }
     }
+    result
 }
 
 pub fn covariance_differences<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
     z: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
     let ncols = x.ncols();
+    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         for j in 0..ncols {
             let sqrt_product_diff = (x[(i, j)].sqrt() * y[(i, j)].sqrt() - z[(i, j)]).abs();
             let sqrt_product_norm = x[(i, j)].sqrt() * y[(i, j)].sqrt() + EPSILON;
-            target[(i, j)] = sqrt_product_diff / sqrt_product_norm;
+            result[(i, j)] = sqrt_product_diff / sqrt_product_norm;
         }
     }
+    result
 }
 
 pub fn textural_variance_sum<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_sum: f64 = x.row(i).sum();
         let y_sum: f64 = y.row(i).sum();
-        target[(i, 0)] = relative_difference(x_sum, y_sum);
+        result[(i, 0)] = relative_difference(x_sum, y_sum);
     }
+    result
 }
 
 pub fn omnivariance_differences<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_prod: f64 = x.row(i).product();
         let y_prod: f64 = y.row(i).product();
-        target[(i, 0)] = relative_difference(x_prod.cbrt(), y_prod.cbrt());
+        result[(i, 0)] = relative_difference(x_prod.cbrt(), y_prod.cbrt());
     }
+    result
 }
 
 pub fn entropy<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
     let ncols = x.ncols();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let mut x_entropy: f64 = 0.;
         let mut y_entropy: f64 = 0.;
@@ -78,61 +82,65 @@ pub fn entropy<'a, T: na::Dim>(
             x_entropy += x[(i, j)] * (x[(i, j)] + EPSILON).ln();
             y_entropy += y[(i, j)] * (y[(i, j)] + EPSILON).ln();
         }
-        target[(i, 0)] = relative_difference(x_entropy, y_entropy);
+        result[(i, 0)] = relative_difference(x_entropy, y_entropy);
     }
+    result
 }
 
 pub fn euclidean_distances<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
     let ncols = x.ncols();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let mut dists: f64 = 0.;
         for j in 0..ncols {
             dists += (x[(i, j)] - y[(i, j)]).pow(2);
         }
-        target[(i, 0)] = dists.sqrt();
+        result[(i, 0)] = dists.sqrt();
     }
+    result
 }
 
 pub fn vector_projected_distances<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
     col: usize,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
+    let ncols = 1;
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
-        target[(i, 0)] = (x[(i, col)] - y[(i, col)]).abs();
+        result[(i, 0)] = (x[(i, col)] - y[(i, col)]).abs();
     }
+    result
 }
 
-pub fn point_projected_distances<'a, T: na::Dim>(
-    x: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+pub fn point_projected_distances<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
+    let ncols = 2;
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
-        target[(i, 0)] = x[(i, 1)].abs();
-        target[(i, 1)] = x[(i, 2)].abs();
+        result[(i, 0)] = x[(i, 1)].abs();
+        result[(i, 1)] = x[(i, 2)].abs();
     }
+    result
 }
 
-pub fn point_to_centroid_distances<'a, T: na::Dim>(
-    x: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+pub fn point_to_centroid_distances<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
+    let ncols = 1;
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, ncols);
     for i in 0..nrows {
         let mut dists: f64 = 0.;
         for j in 0..x.ncols() {
             dists += x[(i, j)].pow(2);
         }
-        target[(i, 0)] = dists.sqrt();
+        result[(i, 0)] = dists.sqrt();
     }
+    result
 }
 
 pub fn anisotropy_planarity_linearity<'a, T: na::Dim>(
@@ -140,64 +148,65 @@ pub fn anisotropy_planarity_linearity<'a, T: na::Dim>(
     y: &'a MatrixView<f64, T, T>,
     col1: usize,
     col2: usize,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_diff = (x[(i, col1)] - x[(i, col2)]) / (x[(i, 0)] + EPSILON);
         let y_diff = (y[(i, col1)] - y[(i, col2)]) / (y[(i, 0)] + EPSILON);
-        target[(i, 0)] = relative_difference(x_diff, y_diff);
+        result[(i, 0)] = relative_difference(x_diff, y_diff);
     }
+    result
 }
 
 pub fn surface_variation<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let x_sum: f64 = x.row(i).sum();
         let y_sum: f64 = y.row(i).sum();
-        target[(i, 0)] =
+        result[(i, 0)] =
             relative_difference(x[(i, 2)] / (x_sum + EPSILON), y[(i, 2)] / (y_sum + EPSILON));
     }
+    result
 }
 
 pub fn sphericity<'a, T: na::Dim>(
     x: &'a MatrixView<f64, T, T>,
     y: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
-        target[(i, 0)] = relative_difference(
+        result[(i, 0)] = relative_difference(
             x[(i, 2)] / (x[(i, 0)] + EPSILON),
             y[(i, 2)] / (y[(i, 0)] + EPSILON),
         );
     }
+    result
 }
 
-pub fn angular_similarity<'a, T: na::Dim>(
-    x: &'a MatrixView<f64, T, T>,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+pub fn angular_similarity<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>) -> DMatrix<f64> {
     let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for i in 0..nrows {
         let numerator = x[(i, 1)];
         let (mut a, mut b, mut c) = (x[(i, 0)], x[(i, 1)], x[(i, 2)]);
         (a, b, c) = (a.pow(2), b.pow(2), c.pow(2));
         let denominator: f64 = (a + b + c).sqrt() + EPSILON;
-        target[(i, 0)] = 1. - 2. * acos((numerator / denominator).abs()) / PI;
+        result[(i, 0)] = 1. - 2. * acos((numerator / denominator).abs()) / PI;
     }
+    result
 }
 
-pub fn parallelity<'a, T: na::Dim>(
-    x: &'a MatrixView<f64, T, T>,
-    col: usize,
-    target: &'a mut MatrixViewMut<f64, T, T>,
-) {
+pub fn parallelity<'a, T: na::Dim>(x: &'a MatrixView<f64, T, T>, col: usize) -> DMatrix<f64> {
+    let nrows = x.nrows();
+    let mut result = DMatrix::zeros(nrows, 1);
     for (i, num) in x.column(col).iter().enumerate() {
-        target[i] = 1. - *num;
+        result[i] = 1. - *num;
     }
+    result
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 extern crate ordered_float;
 use self::ordered_float::OrderedFloat;
-use na::{Const, DMatrix, Dyn, Matrix, RowVector3, Scalar, VecStorage};
+use na::{Const, DMatrix, Dyn, Matrix, Scalar, VecStorage};
 use num_traits::AsPrimitive;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use std::ops::AddAssign;
@@ -43,12 +43,8 @@ pub fn slice_from_knn_indices<'a>(
     let mut selected_points = DMatrix::zeros(nrows, ncols);
     let mut selected_colors = DMatrix::zeros(nrows, ncols);
     for (i, j) in sl_knn_indices.iter().enumerate() {
-        selected_points
-            .row_mut(i)
-            .copy_from(&RowVector3::from_row_slice(&points[*j]));
-        selected_colors
-            .row_mut(i)
-            .copy_from(&RowVector3::from_row_slice(&colors[*j]));
+        selected_points.row_mut(i).copy_from_slice(&points[*j]);
+        selected_colors.row_mut(i).copy_from_slice(&colors[*j]);
     }
     (selected_points, selected_colors)
 }


### PR DESCRIPTION
**Refactor the entire logic behind knn search**
- the knn indices for a point are now computed on the runtime of features.rs, hugely reducing memory overhead
- Adaptations on files other than knn_search.rs were made for the new knn search logic
- Small time optimizations were achieved as well

**Optimizations on memory usage when computing predictors**
- The pooling is now made in-place on the predictors module
- These changes hugely reduce RAM usage when computing predictors

**How great were the optimizations?**
- The peak RAM usage for a pair of PCs, the reference one with more than 20 million points, was less than 40 GB
- The previous version had a peak of about 125 GB RAM usage for the same pair
- The average time for computing features on the reference dataset (on README.md), APSIPA, reduced a little bit. The difference is greater on big PCs.

**New pooling**
- The pooling module was revamped in order to work with the new changes on predictors
- Multiple pooling techniques will be available through the usage of the new struct Pool

**Were there any tradeoffs?**
- Both time and memory usage were improved, so this version implements optiomizations without any cost at all

