### PR TITLE
v1.4.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub fn compute_pointpca2<'a>(
     verbose: bool,
 ) -> na::Matrix1xX<f64> {
     utils::print_if_verbose("Preprocessing", &verbose);
-    let (points_a, colors_a) = preprocessing::preprocess_point_cloud(&points_a, &colors_a);
-    let (points_b, colors_b) = preprocessing::preprocess_point_cloud(&points_b, &colors_b);
+    let (points_a, colors_a) = preprocessing::preprocess_point_cloud(points_a, colors_a);
+    let (points_b, colors_b) = preprocessing::preprocess_point_cloud(points_b, colors_b);
     utils::print_if_verbose("Computing local features", &verbose);
     let local_features =
         features::compute_features(points_a, colors_a, points_b, colors_b, search_size);

--- a/src/ply_manager.rs
+++ b/src/ply_manager.rs
@@ -37,7 +37,7 @@ impl ply::PropertyAccess for Vertex {
             "red" => self.rgb[0] = extract_value(&property) as u8,
             "green" => self.rgb[1] = extract_value(&property) as u8,
             "blue" => self.rgb[2] = extract_value(&property) as u8,
-            _ => panic!("set_property: Unexpected key/property combination."),
+            _ => {},
         }
     }
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -21,10 +21,7 @@ fn vec_mean(
     mean
 }
 
-pub fn duplicate_merging<'a>(
-    points: &'a DMatrix<f64>,
-    colors: &'a DMatrix<u8>,
-) -> (DMatrix<f64>, DMatrix<u8>) {
+pub fn duplicate_merging(points: DMatrix<f64>, colors: DMatrix<u8>) -> (DMatrix<f64>, DMatrix<u8>) {
     let mut points_map: BTreeMap<
         (OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>),
         Vec<(OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>)>,
@@ -65,7 +62,7 @@ pub fn duplicate_merging<'a>(
     (points_result, colors_result)
 }
 
-fn rgb_to_yuv<'a>(rgb: &'a DMatrix<u8>) -> DMatrix<u8> {
+fn rgb_to_yuv(rgb: DMatrix<u8>) -> DMatrix<u8> {
     let (rows, cols) = rgb.shape();
     assert!(
         cols == 3,
@@ -95,11 +92,11 @@ fn rgb_to_yuv<'a>(rgb: &'a DMatrix<u8>) -> DMatrix<u8> {
     yuv
 }
 
-pub fn preprocess_point_cloud<'a>(
-    points: &'a DMatrix<f64>,
-    colors: &'a DMatrix<u8>,
+pub fn preprocess_point_cloud(
+    points: DMatrix<f64>,
+    colors: DMatrix<u8>,
 ) -> (DMatrix<f64>, DMatrix<u8>) {
-    let (points_merged, colors_merged) = duplicate_merging(points, colors);
-    let colors_yuv = rgb_to_yuv(&colors_merged);
-    (points_merged, colors_yuv)
+    let (points, colors) = duplicate_merging(points, colors);
+    let colors = rgb_to_yuv(colors);
+    (points, colors)
 }

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -3,7 +3,7 @@ use na::DMatrix;
 use ordered_float::OrderedFloat;
 use std::collections::BTreeMap;
 
-fn vec_mean(
+fn column_axis_mean(
     vector: &Vec<(OrderedFloat<f64>, OrderedFloat<f64>, OrderedFloat<f64>)>,
 ) -> (f64, f64, f64) {
     let vec_len = vector.len() as f64;
@@ -51,7 +51,7 @@ pub fn duplicate_merging(points: DMatrix<f64>, colors: DMatrix<u8>) -> (DMatrix<
             utils::from_ordered(key.2),
         );
         let colors = points_map.get(&key).unwrap();
-        let colors_mean = vec_mean(colors);
+        let colors_mean = column_axis_mean(colors);
         points_result[(i, 0)] = point.0;
         points_result[(i, 1)] = point.1;
         points_result[(i, 2)] = point.2;
@@ -63,26 +63,18 @@ pub fn duplicate_merging(points: DMatrix<f64>, colors: DMatrix<u8>) -> (DMatrix<
 }
 
 fn rgb_to_yuv(rgb: DMatrix<u8>) -> DMatrix<u8> {
-    let (rows, cols) = rgb.shape();
-    assert!(
-        cols == 3,
-        "Input matrix must have 3 columns representing RGB values"
-    );
+    let rows = rgb.nrows();
     let rgb_f64 = rgb.map(|val| val as f64);
     let r = rgb_f64.column(0);
     let g = rgb_f64.column(1);
     let b = rgb_f64.column(2);
-    let c = DMatrix::from_row_slice(
-        3,
-        3,
-        &[
-            0.2126, 0.7152, 0.0722, -0.1146, -0.3854, 0.5000, 0.5000, -0.4542, -0.0468,
-        ],
-    );
-    let o = na::DVector::from_row_slice(&[0.0, 128.0, 128.0]);
-    let y = (c[(0, 0)] * &r + c[(0, 1)] * &g + c[(0, 2)] * &b).add_scalar(o[0]);
-    let u = (c[(1, 0)] * &r + c[(1, 1)] * &g + c[(1, 2)] * &b).add_scalar(o[1]);
-    let v = (c[(2, 0)] * &r + c[(2, 1)] * &g + c[(2, 2)] * &b).add_scalar(o[2]);
+    let c = [
+        0.2126, 0.7152, 0.0722, -0.1146, -0.3854, 0.5000, 0.5000, -0.4542, -0.0468,
+    ];
+    let o = [0., 128., 128.];
+    let y = (c[0] * &r + c[1] * &g + c[2] * &b).add_scalar(o[0]);
+    let u = (c[3] * &r + c[4] * &g + c[5] * &b).add_scalar(o[1]);
+    let v = (c[6] * &r + c[7] * &g + c[8] * &b).add_scalar(o[2]);
     let mut yuv = DMatrix::zeros(rows, 3);
     for i in 0..rows {
         yuv[(i, 0)] = y[i].round() as u8;


### PR DESCRIPTION
**Preprocessing Module:**
- Improved memory usage by updating ownership
- Minor code refinements

**Ply Manager Module:**
- Rewritten from scratch for improved performance
- Faster PLY file reading with significantly reduced RAM usage
- Reads only the header and vertex payload of PLY files
- Only supports point clouds with colors in the [0, 255] range at the moment
- Compatible with both ASCII and binary formats
- Reads only XYZ and RGB attributes

**lib.rs:**
- Updated for compatibility with new changes